### PR TITLE
Remove cmocka.h from clang-tidy analysis.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks:          '-*,clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,modernize-*,performance-*,portability-*,readability-*,-readability-inconsistent-declaration-parameter-name,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-readability-avoid-const-params-in-decls,-cppcoreguidelines-avoid-non-const-global-variables'
 WarningsAsErrors: ''
-HeaderFilterRegex: '.*'
+HeaderFilterRegex: '.*,-cmocka.h'
 AnalyzeTemporaryDtors: false
 FormatStyle:     file
 CheckOptions:


### PR DESCRIPTION
Fixes #1